### PR TITLE
DDwrapper: Increase performance of creating Datadog style tags

### DIFF
--- a/tags.go
+++ b/tags.go
@@ -1,6 +1,9 @@
 package ddwrapper
 
-import "strings"
+import (
+	"reflect"
+	"unsafe"
+)
 
 type Tags []string
 
@@ -9,9 +12,21 @@ func (t Tags) Pair() []string {
 	if len(t)&1 == 1 {
 		return t
 	}
+
 	tag := make([]string, len(t)/2)
 	for i := 0; i < len(t)/2; i++ {
-		tag[i] = strings.Join([]string{t[i*2], t[i*2+1]}, ":")
+		var b = make([]byte, 0, len(t[i*2])+len(t[i*2+1])+1)
+		b = append(b, t[i*2]...)
+		b = append(b, ':')
+		b = append(b, t[i*2+1]...)
+		tag[i] = bytesToString(b)
 	}
 	return tag
+}
+func bytesToString(bytes []byte) string {
+	sliceHeader := (*reflect.SliceHeader)(unsafe.Pointer(&bytes))
+	return *(*string)(unsafe.Pointer(&reflect.StringHeader{
+		Data: sliceHeader.Data,
+		Len:  sliceHeader.Len,
+	}))
 }


### PR DESCRIPTION
```
Old

goos: darwin
goarch: amd64
pkg: github.com/marcsantiago/ddwrapper
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkTags_Pair2-12          16919018                64.26 ns/op           32 B/op          2 allocs/op
BenchmarkTags_Pair2-12          18334809                63.60 ns/op           32 B/op          2 allocs/op
BenchmarkTags_Pair2-12          18536101                64.85 ns/op           32 B/op          2 allocs/op
BenchmarkTags_Pair4-12           9452908               123.1 ns/op            64 B/op          3 allocs/op
BenchmarkTags_Pair4-12           9538831               123.5 ns/op            64 B/op          3 allocs/op
BenchmarkTags_Pair4-12           9359775               122.7 ns/op            64 B/op          3 allocs/op
BenchmarkTags_Pair6-12           6867252               175.1 ns/op           104 B/op          4 allocs/op
BenchmarkTags_Pair6-12           6718770               176.0 ns/op           104 B/op          4 allocs/op
BenchmarkTags_Pair6-12           6761581               176.0 ns/op           104 B/op          4 allocs/op
BenchmarkTags_Pair8-12           5604896               223.0 ns/op           144 B/op          5 allocs/op
BenchmarkTags_Pair8-12           5321914               233.7 ns/op           144 B/op          5 allocs/op
BenchmarkTags_Pair8-12           4675741               239.0 ns/op           144 B/op          5 allocs/op
PASS
ok      github.com/marcsantiago/ddwrapper       16.083s



New
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkTags_Pair2-12          23014462                52.32 ns/op           32 B/op          2 allocs/op
BenchmarkTags_Pair2-12          21740350                52.61 ns/op           32 B/op          2 allocs/op
BenchmarkTags_Pair2-12          22673940                51.35 ns/op           32 B/op          2 allocs/op
BenchmarkTags_Pair4-12          11928243                98.06 ns/op           64 B/op          3 allocs/op
BenchmarkTags_Pair4-12          11505896                95.87 ns/op           64 B/op          3 allocs/op
BenchmarkTags_Pair4-12          11788960                95.79 ns/op           64 B/op          3 allocs/op
BenchmarkTags_Pair6-12           8974597               133.9 ns/op           104 B/op          4 allocs/op
BenchmarkTags_Pair6-12           8744557               132.7 ns/op           104 B/op          4 allocs/op
BenchmarkTags_Pair6-12           8769777               133.1 ns/op           104 B/op          4 allocs/op
BenchmarkTags_Pair8-12           7632432               158.2 ns/op           144 B/op          5 allocs/op
BenchmarkTags_Pair8-12           7458686               157.4 ns/op           144 B/op          5 allocs/op
BenchmarkTags_Pair8-12           7387502               159.0 ns/op           144 B/op          5 allocs/op

```